### PR TITLE
bundlerのバージョンを更新

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN set -ex \
   && rbenv rehash \
   && rbenv global 2.5.1 \
   && rbenv exec gem update --system \
-  && rbenv exec gem install bundler -v '1.16.1' \
+  && rbenv exec gem install bundler -v '2.1.4' \
   && rbenv rehash \
   && cd /web \
   && bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
-git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.5.1'
 gem 'rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/flyerhzm/bullet.git
-  revision: 5d0d21d2f9be55ffccbd47def40e02212fda78e7
+  revision: 6b6575301dc74c6eb37b76d219df55e12932d538
   specs:
-    bullet (6.0.2)
+    bullet (6.1.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
 
@@ -88,14 +88,14 @@ GEM
     capistrano-rails (1.4.0)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
-    capistrano-rbenv (2.1.4)
+    capistrano-rbenv (2.1.6)
       capistrano (~> 3.1)
       sshkit (~> 1.3)
     capistrano3-puma (4.0.0)
       capistrano (~> 3.7)
       capistrano-bundler
       puma (~> 4.0)
-    capybara (3.29.0)
+    capybara (3.30.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -113,7 +113,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.5)
-    crass (1.0.5)
+    crass (1.0.6)
     daemon-spawn (0.4.2)
     database_cleaner (1.7.0)
     debug_inspector (0.0.3)
@@ -139,9 +139,9 @@ GEM
     factory_bot_rails (5.1.1)
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
-    faker (2.10.0)
-      i18n (>= 1.6, < 1.8)
-    ffi (1.11.3)
+    faker (2.10.1)
+      i18n (>= 1.6, < 2)
+    ffi (1.12.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hirb (0.7.3)
@@ -156,9 +156,9 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    http-form_data (2.1.1)
+    http-form_data (2.2.0)
     http_parser.rb (0.6.0)
-    i18n (1.7.0)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
@@ -176,15 +176,15 @@ GEM
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     method_source (0.9.2)
-    mime-types (3.3)
+    mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
     mimemagic (0.3.3)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    mini_racer (0.2.8)
+    mini_racer (0.2.9)
       libv8 (>= 6.9.411)
-    minitest (5.13.0)
+    minitest (5.14.0)
     multipart-post (2.1.1)
     mysql2 (0.5.3)
     naught (1.1.0)
@@ -205,10 +205,10 @@ GEM
       pry (~> 0.10)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    public_suffix (4.0.1)
+    public_suffix (4.0.3)
     puma (4.3.1)
       nio4r (~> 2.0)
-    rack (2.0.8)
+    rack (2.1.1)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.2.1)
@@ -242,7 +242,7 @@ GEM
       thor (>= 0.20.3, < 2.0)
     rake (13.0.1)
     rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
+    rb-inotify (0.10.1)
       ffi (~> 1.0)
     rbnacl (3.4.0)
       ffi
@@ -255,12 +255,12 @@ GEM
     ridgepole (0.8.5)
       activerecord (>= 5.0.1, < 6.1)
       diffy
-    rspec-core (3.9.0)
-      rspec-support (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
     rspec-expectations (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.0)
+    rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-rails (3.9.0)
@@ -271,7 +271,7 @@ GEM
       rspec-expectations (~> 3.9.0)
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
-    rspec-support (3.9.0)
+    rspec-support (3.9.2)
     rubyzip (2.0.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -283,7 +283,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (3.142.6)
+    selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     simple_oauth (0.3.1)
@@ -319,7 +319,7 @@ GEM
       multipart-post (~> 2.0)
       naught (~> 1.0)
       simple_oauth (~> 0.3.0)
-    tzinfo (1.2.5)
+    tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
@@ -333,7 +333,7 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (4.1.3)
+    webdrivers (4.2.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (>= 3.0, < 4.0)
@@ -395,4 +395,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   2.1.4

--- a/tools/ansible/roles/rbenv/tasks/main.yml
+++ b/tools/ansible/roles/rbenv/tasks/main.yml
@@ -33,4 +33,4 @@
 - name: install bundler
   gem:
     name: bundler
-    version: 1.16.1
+    version: 2.1.4


### PR DESCRIPTION
bundlerのバージョンが1.16.1と古かったので2.1.4に更新する

https通信がデフォルトになるのでGemfileに以下の設定が不要になるらしい
```ruby
git_source(:github) { |repo| "https://github.com/#{repo}.git" }
```

ref: https://qiita.com/takaram/items/084eaa5005bcca2ae6e9