### PR TITLE
対話キーワードの一覧表示機能を削除

### DIFF
--- a/lib/discord/action_selector.rb
+++ b/lib/discord/action_selector.rb
@@ -60,8 +60,6 @@ module ActionSelector
         return InteractionController::create(message_event)
       elsif match_keywords(message_event, Settings::INTERACTION_DESTROY)
         return InteractionController::destroy(message_event)
-      elsif match_keywords(message_event, Settings::INTERACTION_RESPONSE)
-        return InteractionController::list(message_event)
       end
       return InteractionController::response(message_event)
     end

--- a/lib/discord/config/settings.rb
+++ b/lib/discord/config/settings.rb
@@ -23,9 +23,6 @@ module Settings
   # 対話セット削除キーワード
   INTERACTION_DESTROY = /忘却/
 
-  # 対話反応キーワード
-  INTERACTION_RESPONSE = /リスト/
-
   # 飯テロキーワード
   FOOD_RESPONSE = /おなか|お腹|飯テロ/
 

--- a/lib/discord/controllers/interaction_controller.rb
+++ b/lib/discord/controllers/interaction_controller.rb
@@ -31,12 +31,4 @@ module InteractionController
       message_event.send_message(interaction.response)
     end
   end
-
-  def list(message_event)
-    Activity.add(message_event.author, :interaction_list)
-
-    keywords = Interaction.all.map{|interaction| interaction['keyword']}
-    message_event.send_message(I18n.t('interaction.list'))
-    message_event.send_message("```\n#{keywords.join(', ')}\n```")
-  end
 end

--- a/spec/lib/discord/controllers/interaction_controller_spec.rb
+++ b/spec/lib/discord/controllers/interaction_controller_spec.rb
@@ -37,14 +37,4 @@ describe InteractionController do
       expect(Activity.last).to have_attributes(user: author, content: 'interaction_response')
     end
   end
-
-  describe '#list' do
-    before { described_class.list(message_event) }
-
-    let(:message) { 'リスト' }
-
-    it 'save activity' do
-      expect(Activity.last).to have_attributes(user: author, content: 'interaction_list')
-    end
-  end
 end


### PR DESCRIPTION
リストで文字数制限に引っかかってエラーが出ていたので修正しようと思ったけど、
不穏なキーワードがあったので逆に表示できないようにした。

fix #39 