### PR TITLE
masterブランチへのpushを契機に自動でデプロイする

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: deploy
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    container:
+      image: utyosu/build-rails:latest
+
+    steps:
+    - uses: actions/checkout@master
+    - run: |
+        mkdir -p /root/.ssh/
+        echo "${{ secrets.GCE_DEPLOY_SSH_CONFIG }}" >> /etc/ssh/ssh_config
+        echo "${{ secrets.GCE_PRIVATE_KEY }}" > /root/.ssh/id_rsa
+        chmod 600 /root/.ssh/id_rsa
+        eval `ssh-agent`
+        ssh-add /root/.ssh/id_rsa
+        bundle config set without development
+        bundle install
+        bundle exec cap production deploy BRANCH=add_deploy_workflow

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: test
 
 on: [pull_request]
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,18 +4,20 @@ default: &default
   encoding: utf8mb4
   collation: utf8mb4_bin
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: root
   socket: /var/run/mysqld/mysqld.sock
 
 development:
   <<: *default
+  username: dev_ops
   database: discord_recruitment_bot_development
 
 test:
   <<: *default
+  username: root
   database: discord_recruitment_bot_test
 
 production:
   <<: *default
+  username: ops
   database: discord_recruitment_bot_production
   password: <%= ENV['DATABASE_PASSWORD'] %>

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,13 +1,5 @@
 role :app, %w{ops@gce}
 
-server "gce",
-  user: "ops",
-  roles: %w{app},
-  ssh_options: {
-    user: "ops",
-    keys: %w(/home/ops/.ssh/google_compute_engine),
-    forward_agent: false,
-    auth_methods: %w(publickey)
-  }
+server "gce", user: "ops", roles: %w{app}
 
 set :rails_env, :production

--- a/tools/ansible/roles/mysql/tasks/main.yml
+++ b/tools/ansible/roles/mysql/tasks/main.yml
@@ -3,3 +3,14 @@
   apt:
     name:
       - mysql-server
+
+- name: show users in mysql
+  become: yes
+  shell: mysql -e 'SELECT User FROM mysql.user;'
+  register: mysql_users
+  changed_when: False
+
+- name: setup mysql server
+  become: yes
+  shell: mysql -e 'create user ops; grant all on *.* to 'ops'; create database discord_recruitment_bot_production character set utf8mb4;'
+  when: '"ops" not in mysql_users.stdout'

--- a/tools/ci/Dockerfile
+++ b/tools/ci/Dockerfile
@@ -1,5 +1,5 @@
 # ビルド方法 (プロジェクトルートで実行)
-# $ docker build -t build-rails . -f tools/cloud_build/Dockerfile
+# $ docker build -t utyosu/build-rails:latest . -f tools/ci/Dockerfile
 
 FROM ubuntu:16.04
 


### PR DESCRIPTION
- masterブランチへのpushを契機に自動でデプロイするようにした。
- 本番環境はMySQLにroot権限で入れなかったのでユーザでログインするように修正した。
(テスト環境はDockerなのでrootでログインできるのでそのまま)

