### PR TITLE
CI実行時にブランチ名を設定するようにした

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,6 @@
 name: build
 
-on:
-  pull_request:
-  push:
-    branches:
-    - master
+on: [pull_request]
 
 jobs:
   build:
@@ -16,10 +12,5 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: set coverall repo token
-      run: 'echo "repo_token: ${{ secrets.COVERALLS_REPO_TOKEN }}" > .coveralls.yml'
-
     - name: run test
       run: . tools/ci/test.sh
-      env:
-        CI: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,20 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
-    - run: |
+
+    - name: set coverall repo token
+      run: 'echo "repo_token: ${{ secrets.COVERALLS_REPO_TOKEN }}" > .coveralls.yml'
+
+    - name: set master to branch name
+      run: git checkout -b master
+
+    - name: run test
+      run: . tools/ci/test.sh
+      env:
+        CI: true
+
+    - name: deploy
+      run: |
         mkdir -p /root/.ssh/
         echo "${{ secrets.GCE_DEPLOY_SSH_CONFIG }}" >> /etc/ssh/ssh_config
         echo "${{ secrets.GCE_PRIVATE_KEY }}" > /root/.ssh/id_rsa


### PR DESCRIPTION
GithubActionsはデフォルトのブランチ名が `(HEAD detached at 578d027)` のように設定されている。
このままcoverallsに登録するとブランチ名が分からずバッジが取得できないため、ブランチ名を設定するようにした。