### PR TITLE
CIでgitコマンドが使えるようにする

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
       image: utyosu/build-rails:latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
 
     - name: set coverall repo token
       run: 'echo "repo_token: ${{ secrets.COVERALLS_REPO_TOKEN }}" > .coveralls.yml'


### PR DESCRIPTION
GithubActionsのcheckoutがmaster版だとgitコマンドが使えないので、gitコマンドの使えるv1に変更する