### PR TITLE
production環境でlib以下が読み込まれない不具合の修正

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,6 @@ module IsApi
     config.time_zone = 'Tokyo'
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
-    config.autoload_paths += Dir["#{config.root}/lib/**/"]
+    config.paths.add 'lib', eager_load: true
   end
 end


### PR DESCRIPTION
Rails5で自動読み込みの仕様が変わっていたみたいです。
autoload_pathsではなくpathsで指定するとOKのようです。
https://qiita.com/joooee0000/items/3ab0f3d791e0d0beb639