### PR TITLE
simplecovとcoverallの依存を解消

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,11 +39,16 @@ group :test do
   gem "coveralls", require: false
   gem "rspec-rails"
   gem "selenium-webdriver"
-  # simplecov 0.18.2(厳密にはsimplecov-html 0.12.0)で
-  # 出力コードが表示できない不具合があるので一旦0.18.2に固定する
-  # issueは上がっている模様
-  # https://github.com/colszowka/simplecov-html/issues/92
-  gem "simplecov", "= 0.18.1", require: false
+
+  # simplecov
+  #   simplecov 0.18.2(厳密にはsimplecov-html 0.12.0)で
+  #   出力コードが表示できない不具合があるので一旦0.18.2に固定する
+  #   issueは上がっている模様
+  #   https://github.com/colszowka/simplecov-html/issues/92
+  #
+  #   coverallsがsimplecov 0.16系までしか対応していないので
+  #   0.16.1に固定する。対応したらバージョンアップする。
+  gem "simplecov", "~> 0.16.0", require: false
   gem "webdrivers"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,12 +117,12 @@ GEM
     config (2.2.1)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
-    coveralls (0.7.1)
-      multi_json (~> 1.3)
-      rest-client
-      simplecov (>= 0.7)
-      term-ansicolor
-      thor
+    coveralls (0.8.23)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.16.1)
+      term-ansicolor (~> 1.3)
+      thor (>= 0.19.4, < 2.0)
+      tins (~> 1.6)
     crass (1.0.6)
     daemon-spawn (0.4.2)
     database_cleaner (1.8.2)
@@ -230,6 +230,7 @@ GEM
     jaro_winkler (1.5.4)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    json (2.3.0)
     libv8 (7.3.492.27.1)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -253,7 +254,6 @@ GEM
     mini_racer (0.2.9)
       libv8 (>= 6.9.411)
     minitest (5.14.0)
-    multi_json (1.14.1)
     multipart-post (2.1.1)
     mysql2 (0.5.3)
     naught (1.1.0)
@@ -371,10 +371,11 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     simple_oauth (0.3.1)
-    simplecov (0.18.1)
+    simplecov (0.16.1)
       docile (~> 1.1)
-      simplecov-html (~> 0.11.0)
-    simplecov-html (0.11.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     slack-ruby-client (0.14.5)
       activesupport
       faraday (>= 0.9)
@@ -492,7 +493,7 @@ DEPENDENCIES
   rubocop-rails
   sass-rails
   selenium-webdriver
-  simplecov (= 0.18.1)
+  simplecov (~> 0.16.0)
   slack-ruby-client
   slim-rails
   timers


### PR DESCRIPTION
coverallsの実行が失敗していた。
原因はcoverallsに対応するsimplecovが新しすぎたため。

coveralls 0.7.1の依存解決がsimplecov 0.7以上という大雑把なので、
coverallsが古いままsimplecovだけバージョンが上がってしまった。

coveralls 0.8.23、simplecov 0.16.1に落ち着かせた。